### PR TITLE
Fix rendering explicit template

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,11 +7,13 @@ gemspec
 
 gem "phlex", github: "phlex-ruby/phlex"
 gem "phlex-testing-capybara", github: "phlex-ruby/phlex-testing-capybara"
-gem "rspec-rails"
 gem "combustion"
 gem "rubocop"
 gem "solargraph"
 gem "view_component"
 gem "appraisal", github: "excid3/appraisal", branch: "fix-bundle-env"
 gem "yard"
+
+# Ensure rails is loaded before rspec-rails.
 gem "rails"
+gem "rspec-rails"

--- a/spec/internal/app/controllers/articles_controller.rb
+++ b/spec/internal/app/controllers/articles_controller.rb
@@ -8,4 +8,8 @@ class ArticlesController < ActionController::Base
 	end
 
 	def show; end
+
+	def preview
+		render Articles::PreviewView
+	end
 end

--- a/spec/internal/app/views/articles/preview_view.rb
+++ b/spec/internal/app/views/articles/preview_view.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Articles::PreviewView < Phlex::HTML
+	def template
+		render(template: "articles/show")
+	end
+end

--- a/spec/internal/config/routes.rb
+++ b/spec/internal/config/routes.rb
@@ -9,4 +9,5 @@ Rails.application.routes.draw do
 
 	get "articles/index", to: "articles#index"
 	get "articles/show", to: "articles#show"
+	get "articles/preview", to: "articles#preview"
 end

--- a/spec/layout_spec.rb
+++ b/spec/layout_spec.rb
@@ -14,4 +14,10 @@ RSpec.describe "Layouts", type: :request do
 
 		expect(response.body).to eq %(<!DOCTYPE html><html><head><title>Article</title></head><body><main>\n<h1>Article</h1>\n</main></body></html>)
 	end
+
+	it "supports rendering templates" do
+		get "/articles/preview"
+
+		expect(response.body).to eq %(<!DOCTYPE html><html><head><title>Article</title></head><body><main>\n<h1>Article</h1>\n</main></body></html>)
+	end
 end


### PR DESCRIPTION
- Define `Rails::VERSION` before requiring rspec-rails
- Add failing test for rendering explicit template
